### PR TITLE
Return the Page sans direct downloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,277 @@
+<!DOCTYPE html>
+<html class=""><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    
+    <title>Unigram</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta property="og:title" content="Telegram for Windows">
+    <meta property="og:image" content="https://osx.telegram.org/updates/site/logo.png">
+    <meta property="og:site_name" content="Unigram">
+    <meta property="og:description" content="Experience Telegram on your laptop in a seamless way.">
+    
+    <meta name="telegram:channel" content="@unigram">
+    
+    <link href="/img/bootstrap.min.css" rel="stylesheet">
+    
+    <link href="/img/telegram.css" rel="stylesheet" media="screen">
+  </head>
+  <body class="">
+    <div id="fb-root"></div>
+    <div class="tl_page_wrap">
+      <div class="container clearfix tl_page_container  tl_main_page_container">
+        <div class="tl_page">
+          <div class="tl_main_wrap">
+  <div class="tl_main_logo_wrap">
+    <a href="https://unigramdev.github.io/" class="tl_main_logo">
+      <div class="tl_main_logo play" style="background-image: url(/img/t_logo_sprite.svg);"></div>
+      <h1 class="tl_main_logo_title">Unigram</h1>
+    </a>
+    <p class="tl_main_logo_lead"></p>
+  </div>
+</div>
 
+<div class="td_content_wrap clearfix">
+  <div class="td_screenshot_macos"></div>
+
+  <div class="td_download_wrap"><a href="https://www.microsoft.com/store/apps/9n97zckpd60q" class="td_download_btn"><i class="td_download_icon"></i> Get Unigram for <b>Windows</b></a></div>
+
+  <div id="td_versions">
+    <div class="td_about_license">This software is available under <a href="https://github.com/UnigramDev/Unigram/blob/develop/LICENSE">GPL v3</a> license.<br><br>Source code is available on <a href="https://github.com/UnigramDev/Unigram">GitHub</a>.<br><br>Unigram is only available for download in the Microsoft Store
+  </div>
+
+  <div class="td_changelog_wrap">
+    <a name="changelog" id="changelog"></a>
+    <div id="dev_page_content_wrap" class=" ">
+  <div class="dev_page_bread_crumbs"></div>
+  <h1 id="dev_page_title">Version history</h1>
+
+  <div id="dev_page_content">
+  <h3><a class="anchor" name="v10-1-2023-09-22" href="https://unigramdev.github.io/#v10-1-2023-09-22"><i class="anchor-icon"></i></a>10.1 <strong>2023-09-22</strong></h3>
+  <ul>
+  <strong>STORIES FOR CHANNELS, YOUR MUSIC IN STORIES AND MORE</strong><br>
+  <strong>Stories for Channels</strong><br>
+  <li>Telegram users can boost their favorite channels, allowing the channel to post stories.</li>
+  <li>Channels can ask subscribers for boosts using a special link.</li>
+  <li>More boosts make the channel level up – able to post more stories per day.</li>
+  <strong>Reaction Stickers in Stories</strong><br>
+  <li>Users can add reaction stickers to their story, letting viewers share emotions in one tap.</li>
+  <strong>Music in Stories</strong><br>
+  <li>Anyone can use audio files on their device in their story – adding music, narration and effects.</li>
+  <strong>View-Once Media</strong><br>
+  <li>Self-destructing media now has a view-once setting.</li>
+  <li>View-Once media is permanently deleted from the chat when the recipient opens it.</li>
+  <strong>New Login Alerts</strong><br>
+  <li>When a new device logs in to your account, a login alert appears at the top of your chat list.</li>
+  <li>If you don't recognize the new device, tap 'No, it's not me!' to instantly secure your account.</li>
+  <strong>and More</strong><br>
+  <li>For all the changes from this update, including what's new on Android and iOS, check out the <a href=https://telegram.org/blog/channel-stories>latest blog post</a>.</li>
+  </ul>
+  <div id="dev_page_content">
+  <h3><a class="anchor" name="v10-0-2023-08-15" href="https://unigramdev.github.io/#v10-0-2023-08-15"><i class="anchor-icon"></i></a>10.0 <strong>2023-08-15</strong></h3>
+  <ul>
+  <li>Unigram 10.0 came out today bringing quite a bit of new features. As Telegram turned 10 years old yesterday, I’ll leave the explanations to the <a href=https://telegram.org/blog/stories>official blog post.</a></li>
+  </ul>
+  <div id="dev_page_content">
+  <h3><a class="anchor" name="v9-0-2022-09-16" href="https://unigramdev.github.io/#v9-0-2022-09-16"><i class="anchor-icon"></i></a>9.0 <strong>2022-09-16</strong></h3>
+  <ul>
+  <strong>INFINITE REACTIONS, EMOJI STATUSES AND MUCH MORE</strong><br>
+  <strong>Infinite Reactions</strong><br>
+  <li>A new expandable reaction menu was added in private chats and groups.</li>
+  <li>All users get access to dozens of new reactions, including reactions previously reserved for Premium users.</li>
+  <li>The reactions you use most frequently will always be displayed at the top.</li>
+  <li>Premium users can react to messages with thousands of custom emoji and add up to 3 reactions to each message.</li>
+  <strong>Reaction Management</strong><br>
+  <li>Group admins can control whether custom reactions are allowed in their groups.</li>
+  <li>We've added an option to report spam when opening a user's profile from a reaction. (Internet rule number N: if something exists, sooner or later, it will be used for spam).</li>
+  <strong>Premium: Emoji Statuses</strong><br>
+  <li>Premium users can add an animated emoji status next to their name to display their current activity.</li>
+  <li>To set a status, tap your Premium badge in the chat list or Settings.</li>
+  <li>Popular suggestions for working, sleeping, traveling and more will be shown at the top.</li>
+  <li>To set a status for a specific duration like 1 hour or 2 days, press and hold the emoji.</li>
+  <strong>New Username Links</strong><br>
+  <li>A new format was supported for username links, in addition to "t.me/username." You can now open Telegram accounts, groups or channels using links like "username.t.me" or "https://username.t.me."</li>
+  <strong>Improved Login Flow</strong><br>
+  <li>We've improved the registration and login experience with slick animations and a smoother UI.</li>
+  <li>If you frequently re-login on Telegram, you can sign in faster using your email.</li>
+  </ul>
+  <h3><a class="anchor" name="v8-9-2022-08-12" href="https://unigramdev.github.io/#v8-9-2022-08-12"><i class="anchor-icon"></i></a>8.9 <strong>2022-08-12</strong></h3>
+  <ul>
+  <strong>ANIMATED EMOJI IN MESSAGES, NEW STICKER PANEL, PRIVACY SETTINGS FOR VOICE MESSAGES, AND GIFTING TELEGRAM PREMIUM</strong><br>
+  <strong>New Sticker Panel</strong><br>
+  <li>Switch between sticker, emoji and GIF tabs to quickly find what you're looking for.</li>
+  <li>Enjoy a more vibrant design with semi-transparency and improved scrolling performance on older devices.</li>
+  <li>When typing a message, the sticker button turns into an emoji button that opens the emoji panel.</li>
+  <strong>Premium: Custom Emoji Packs</strong><br>
+  <li>Add animated emoji from 10 new custom packs – with countless more coming.</li>
+  <li>Get animated emoji suggestions from your packs when you enter any static emoji.</li>
+  <li>Press and hold on a message containing emoji to see which packs were used.</li>
+  <li>Create your own custom emoji packs for Premium subscribers.</li>
+  <li>All Telegram users can see emoji from any pack — and try them out for free in the Saved Messages chat.</li>
+  <strong>Premium: Privacy Settings for Voice Messages</strong><br>
+  <li>Control who can send or forward you voice messages in Settings > Privacy and Security with Telegram Premium.</li>
+  <li>Create exceptions to add individual users or groups of users.</li>
+  <strong>Gifting Telegram Premium</strong><br>
+  <li>Send a prepaid Premium subscription to any user from their profile page. </li>
+  <li>Choose from a 3, 6 or 12 month duration – at a discounted price.</li>
+  </ul>
+  <h3><a class="anchor" name="v8-8-2022-06-19" href="https://unigramdev.github.io/#v8-8-2022-06-19"><i class="anchor-icon"></i></a>8.8 <strong>2022-06-19</strong></h3>
+  <ul>
+  <strong>700 MILLION USERS AND TELEGRAM PREMIUM</strong><br>
+  <strong>NEW PREMIUM FEATURES</strong><br>
+  <strong>Premium: 4 GB Uploads</strong><br>
+  <li>Send media and files each up to 4 GB in size.</li>
+  <strong>Premium: Faster Downloads</strong><br>
+  <li>Download media and files at the fastest possible speed, with no limits.</li>
+  <strong>Premium: Doubled Limits</strong><br>
+  <li>Follow up to 1000 channels.</li>
+  <li>Connect 4 accounts in any app.</li>
+  <li>Organize your chats into 20 folders, holding 200 chats each.</li>
+  <li>Pin 10 chats in your main list.</li>
+  <li>Reserve up to 20 public t.me links.</li>
+  <li>Save 400 favorite GIFs and 10 favorite stickers.</li>
+  <li>Write a longer bio for your profile and include links.</li>
+  <li>Include longer captions for photos and videos.</li>
+  <strong>Premium: Voice-to-Text</strong><br>
+  <li>Get a new button next to any voice message to generate a transcript of its audio.</li>
+  <strong>Premium: Unique Reactions and Stickers</strong><br>
+  <li>React with even more emoji, including :clown: and :hearteyes:</li>
+  <li>Send unique stickers with additional effects, updated monthly.</li>
+  <strong>Premium: Chat Management</strong><br>
+  <li>Set a default chat folder or enable tools to auto-archive and hide new chats.</li>
+  <strong>Premium: Badges and Animated Profile Pictures</strong><br>
+  <li>Subscribers have a badge next to their name, showing they help support Telegram.</li>
+  <li>Show off your profile video that will be animated for everyone in chats and the chat list.</li>
+  <strong>Premium: No Ads</strong><br>
+  <li>Sponsored Messages that are sometimes shown in public channels will no longer appear.</li>
+  <strong>NEW FREE FEATURES</strong><br>
+  <strong>Join Requests for Public Groups</strong><br>
+  <li>Enable join requests for your public groups – no invite links required.</li>
+  <li>Users who open the group will see an 'Apply to Join Group' button.</li>
+  <li>Once approved by an admin, users will be able to participate in the chat.</li>
+  <strong>Verification Badges in Chats</strong><br>
+  <li>Verified groups and channels now also show their badge at the top of the chat.</li>
+  <strong>Better Bots</strong><br>
+  <li>Include a photo or video in the "What can this bot do?" section of your bot.</li>
+  <li>Bots that are integrated into the attachment menu can be programmed to work in groups and channels.</li>
+  </ul>
+  
+  <h3><a class="anchor" name="v8-6-2022-03-11" href="https://unigramdev.github.io/#v8-6-2022-03-11"><i class="anchor-icon"></i></a>8.6 <strong>2022-03-11</strong></h3>
+  <ul>
+  <strong>DOWNLOAD MANAGER, LIVE STREAMS WITH OTHER APPS AND MORE</strong><br>
+  <strong>Download Manager</strong><br>
+  <li>Check the status of media and file downloads by tapping the new icon in the Search bar. </li>
+  <li>View recently downloaded files from the new ‘Downloads’ tab in Search.</li>
+  <li>Pause and resume unfinished downloads.</li>
+  <strong>Live Streams with other apps</strong><br>
+  <li>Manage Live Streams in your groups and channels using external software such as OBS Studio or XSplit Broadcaster.</li>
+  <strong>Phone Number Links</strong><br>
+  <li>Share a direct t.me link to your phone number that instantly opens a chat with you.</li>
+  <li>Use the full number in international format, like t.me/+123456789</li>
+  </ul>
+  
+  <h3><a class="anchor" name="v8-5-2022-01-31" href="https://unigramdev.github.io/#v8-5-2022-01-31"><i class="anchor-icon"></i></a>8.5 <strong>2022-01-31</strong></h3>
+  <ul>
+  <strong>VIDEO STICKERS, BETTER REACTIONS AND MORE</strong><br>
+  <strong>Video Stickers</strong><br>
+  <li>Use a new type of detailed stickers with smooth animations.</li>
+  <li>Create new sets by sending .webm videos to @stickers.</li>
+  <li>Bring your custom animated stickers from other apps.</li>
+  <strong>Reactions</strong><br>
+  <li>Right click a message for more reactions. </li>
+  <li>Group and Channel admins can enable reactions in their chat via Chat Info > Edit > Reactions.</li>
+  <li>See real-time animations in chat when a user reacts to your message.</li>
+  <li>React with additional emoji: 🥰🤯🤔🤬👏. </li>
+  <strong>Read Status for Reactions</strong><br>
+  <li>Tap the new button in chats to jump to your messages that have unseen reactions.</li>
+  <li>Watch the animations for unseen reactions play when you hit the button.</li>
+  </ul>
+  
+  <h3><a class="anchor" name="v8-4-2022-01-02" href="https://unigramdev.github.io/#v8-4-2022-01-02"><i class="anchor-icon"></i></a>8.4 <strong>2022-01-02</strong></h3>
+  <ul>
+  <strong>SPOILERS AND TRANSLATION</strong><br>
+  <strong>Spoilers</strong><br>
+  <li>Select text when typing and choose 'Spoiler' formatting to hide some or all of the contents of a message.</li>
+  <li>Tap the spoiler animation in chat to reveal its hidden text.</li>
+  <li>Spoiler formatting hides text in chat, as well as in the chat list and notifications.</li>
+  <strong>Translation</strong><br>
+  <li>Turn on the Translation option in Settings > Languages. </li>
+  <li>Press and hold a message to translate it into another language.</li>
+  </ul>
+  
+  <h3><a class="anchor" name="v8-3-2021-12-07" href="https://unigramdev.github.io/#v8-3-2021-12-07"><i class="anchor-icon"></i></a>8.3 <strong>2021-12-07</strong></h3>
+  <ul>
+  <strong>PROTECTED CONTENT, DELETE BY DATE, DEVICE MANAGEMENT AND MORE</strong><br>
+  <strong>Protected Content in Groups and Channels</strong><br>
+  <li>Content creators can restrict the ability to forward messages from their groups and channels.</li>
+  <li>When forwarding is restricted, users will also be unable to directly save media from the chat or take screenshots.</li>
+  <li>Toggle this option on or off via Chat Info > Group / Channel Type.</li>
+  <strong>Delete Messages by Date</strong><br>
+  <li>Clear messages in one-on-one chats from a specific date or period of time.</li>
+  <li>Tap the date header in a chat to open the calendar and select a single day or range to delete.</li>
+  <strong>Manage Connected Devices</strong><br>
+  <li>Choose how long a device may stay inactive before it's logged out automatically.</li>
+  <li>Select a device to control whether it is allowed to accept Calls or new Secret Chats.</li>
+  <strong>Anonymous Posting in Public Groups</strong><br>
+  <li>Comment as one of your channels in public groups and channel comments.</li>
+  <li>Tap the profile picture next to the message bar to choose which channel you will appear as when you send the message.</li>
+  </ul>
+  
+  <h3><a class="anchor" name="v8-1-2021-09-19" href="https://unigramdev.github.io/#v8-1-2021-09-19"><i class="anchor-icon"></i></a>8.1 <strong>2021-09-19</strong></h3>
+  <ul>
+  <strong>CHAT THEMES, INTERACTIVE EMOJI, READ RECEIPTS IN GROUPS AND LIVE STREAM RECORDING</strong><br>
+  <strong>Chat Themes</strong><br>
+  <li>Choose one of 8 new preset themes for any individual private chat.</li>
+  <li>Tap the chat header > More (⋯) > 'Change Colors' to pick a theme.</li>
+  <li>Both chat participants will see the same theme in that chat – on all their devices.</li>
+  <li>Each new theme features colorful gradient message bubbles, beautifully animated backgrounds and unique background patterns.</li>
+  <li>All chat themes have day and night versions and will follow your overall dark mode settings.</li>
+  <li>More chat themes coming soon.</li>
+  <strong>Interactive Emoji</strong><br>
+  <li>Some animated emoji now have fullscreen effects.</li>
+  <li>Send 🎆 🎉 🎈 👍 💩 or ❤️ to any private chat, then tap on the animated emoji to launch the effect.</li>
+  <li>If your chat partner also has the chat open, you will both see the effects and feel the vibrations simultaneously.</li>
+  <li>See the "Watching" status when your chat partner is enjoying emoji effects with you.</li>
+  <li>More interactive emoji coming soon.</li>
+  <strong>Read Receipts in Small Groups</strong><br>
+  <li>Select one of your outgoing messages in small groups to see who recently viewed it.</li>
+  <li>To protect privacy, read receipts are only stored for 7 days after the message was sent.</li>
+  <strong>Record Live Streams and Video Chats</strong><br>
+  <li>Record video and audio from live broadcasts in your group or channel.</li>
+  <li>Admins can start recording from the Settings menu (⋯).</li>
+  <li>Choose between recording in portrait or landscape orientation.</li>
+  <li>Finished recordings are sent to the admin's Saved Messages and can be easily shared.</li>
+  </ul>
+  
+  <h3><a class="anchor" name="v7-8-2021-06-25" href="https://unigramdev.github.io/#v7-8-2021-06-25"><i class="anchor-icon"></i></a>7.8 <strong>2021-06-25</strong></h3>
+  <ul>
+  <strong>GROUP VIDEO CALLS AND ANIMATED BACKGROUNDS</strong><br>
+  <strong>Group Video Calls</strong><br>
+  <li>Start video conferences from Voice Chats in any group.</li>
+  <li>Share your screen or video from your camera with up to 30 participants (limit to be increased soon).</li>
+  <li>Talk without video with an unlimited number of participants.</li>
+  <li>Create voice chats from the info page of any group where you are an admin.</li>
+  <li>Group video calls are supported natively on all devices, including iPads and laptops.</li>
+  <strong>Animated Backgrounds</strong><br>
+  <li>Meet animated backgrounds for chats – first time in a messaging app! These multi-color gradient backgrounds are generated algorithmically and move beautifully every time you send a message.</li>
+  <li>Create your own backgrounds in Appearance Settings by selecting unique combinations of colors and applying any of the dozens of patterns. </li>
+  <li>Share your animated backgrounds with friends and family to upgrade them to a new level of messaging experience.</li>
+  <li>Choose between dozens of new gorgeous animated backgrounds in Appearance Settings > Background.</li>
+  <li>Backgrounds are now partially visible through the header and the footer in chats.</li>
+  
+  </div>
+  
+</div>
+  </div>
+</div>
+          
+        </div>
+      </div>
+    </div>
+    <script src="/img/main.js.download"></script>
+    
+    <script>backToTopInit("Go up");
+removePreloadInit();
+</script><a class="back_to_top_wrap" onclick="backToTopGo()" style="width: 1517px;"><div class="back_to_top" style="height: 1264px;"><i class="icon icon-to-top"></i>Go up</div></a>
+  
+
+<!-- page generated in 20.91ms -->
+</body></html>

--- a/index.html
+++ b/index.html
@@ -256,6 +256,7 @@
   <li>Share your animated backgrounds with friends and family to upgrade them to a new level of messaging experience.</li>
   <li>Choose between dozens of new gorgeous animated backgrounds in Appearance Settings > Background.</li>
   <li>Backgrounds are now partially visible through the header and the footer in chats.</li>
+  </ul>
   
   </div>
   


### PR DESCRIPTION
Right now https://unigramdev.github.io/ shows a blank page.

That is - there's no 404 (that would clearly indicate that the site is down), nor is there an explanation about why it's blank (because Direct downloads are not a thing anymore), nor does it lead people to the Store to download the app.

I believe that one of the few things should happen to resolve this problem:

- Shutting the GitHub Page down (now it'll show error 404 to users that may find this URL somewhere);
- Adding a clear message about the shutdown of the Beta program and unavailability of the Direct installation/downloads option;
- Simply ommiting the Direct downloads on the page and adding a disclaimer about Unigram availability.

In this PR I decided to do the latter.

Also incorporated _some_ of the changes from #9 (closing the `ul` tag at the end).